### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
 AutoPWM	KEYWORD1
 
 
-autoPrescaler  KEYWORD2
-update KEYWORD2
-off KEYWORD2
+autoPrescaler	KEYWORD2
+update	KEYWORD2
+off	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords